### PR TITLE
Modify to add : poloing in running state by network interface

### DIFF
--- a/service/computing/api_waiters.go
+++ b/service/computing/api_waiters.go
@@ -118,6 +118,11 @@ func (c *Client) WaitUntilInstanceRunning(ctx context.Context, input *DescribeIn
 				Expected: "running",
 			},
 			{
+				State:   aws.SuccessWaiterState,
+				Matcher: aws.PathAllWaiterMatch, Argument: "ReservationSet[].InstancesSet[].NetworkInterfaceSet[].Status",
+				Expected: "in-use",
+			},
+			{
 				State:    aws.RetryWaiterState,
 				Matcher:  aws.ErrorWaiterMatch,
 				Expected: "Client.InvalidParameterNotFound.Instance",


### PR DESCRIPTION
# issue
* poling for creating instance with `WaitUntilInstanceRunning`, failed
* then describe this instance, the status is `pending`

# implement
* check network interface's state in poling for creating instances